### PR TITLE
Update code basis

### DIFF
--- a/cpp/3L-VehicleRouting/ContainerLoading/include/ContainerLoading/Algorithms/PlacementPoints.h
+++ b/cpp/3L-VehicleRouting/ContainerLoading/include/ContainerLoading/Algorithms/PlacementPoints.h
@@ -157,7 +157,8 @@ class PlacementPointGenerator
         std::vector<Cuboid>& items,
         Axis axis,
         std::vector<std::vector<int>>& itemSpecificModifiedItemDimensions,
-        std::vector<boost::dynamic_bitset<>>& itemSpecificPlacementPointsRightPrime,
+        const std::vector<boost::dynamic_bitset<>>& itemSpecificPlacementPointsLeft,
+        std::vector<boost::dynamic_bitset<>>& itemSpecificPlacementPointsRight,
         const std::vector<boost::dynamic_bitset<>>& preliminaryItemSpecificMeetInTheMiddleSets);
 
     static void RemoveRedundantPatterns(std::vector<Cuboid>& items,
@@ -180,7 +181,7 @@ class PlacementPointGenerator
         ConvertPlacementBitsetToVector(const ItemPlacementPatternsBitset& itemSpecificPatternBitset);
 
     ////static std::vector<int64> DetermineStartPointsFlatSpan(const std::vector<int64>& patterns); // Keep for
-    ///reference.
+    /// reference.
     static std::vector<int64>
         DetermineEndPoints(const std::vector<int64>& patterns, int dim, int rotDim, bool enableRotation);
 

--- a/cpp/3L-VehicleRouting/ContainerLoading/include/ContainerLoading/LoadingChecker.h
+++ b/cpp/3L-VehicleRouting/ContainerLoading/include/ContainerLoading/LoadingChecker.h
@@ -10,6 +10,8 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/functional/hash.hpp>
 
+#include <chrono>
+
 namespace ContainerLoading
 {
 using namespace Algorithms;
@@ -36,6 +38,8 @@ class LoadingChecker
             mInfSets[flag & Parameters.LoadingProblem.LoadingFlags].reserve(reservedSize);
             mUnknownSets[flag & Parameters.LoadingProblem.LoadingFlags].reserve(reservedSize);
         }
+
+        mStartTime = std::chrono::high_resolution_clock::now();
     }
 
     [[nodiscard]] std::vector<Cuboid>
@@ -82,6 +86,7 @@ class LoadingChecker
 
     [[nodiscard]] bool CustomerCombinationInfeasible(const boost::dynamic_bitset<>& customersInRoute) const;
     void AddInfeasibleCombination(const boost::dynamic_bitset<>& customersInRoute);
+    [[nodiscard]] double GetElapsedTime();
 
     [[nodiscard]] Collections::SequenceVector GetFeasibleRoutes() const;
     [[nodiscard]] size_t GetNumberOfFeasibleRoutes() const;
@@ -97,13 +102,31 @@ class LoadingChecker
 
     [[nodiscard]] boost::dynamic_bitset<> MakeBitset(size_t size, const Collections::IdVector& sequence) const;
 
+    [[nodiscard]] std::unordered_map<double, Collections::IdVector> GetFeasibleRoutesWithTimeStamps()
+    {
+        return mCompleteFeasSeqWithTimeStamps;
+    };
+
+    void AddTailTournamentConstraint(const Collections::IdVector& sequence)
+    {
+        auto elapsed = GetElapsedTime();
+        mTailTournamentConstraintsWithTimeStamps.insert({elapsed, sequence});
+    }
+    [[nodiscard]] std::unordered_map<double, Collections::IdVector> GetTailTournamentConstraints() const
+    {
+        return mTailTournamentConstraintsWithTimeStamps;
+    }
+
   private:
+    std::chrono::high_resolution_clock::time_point mStartTime;
     std::unique_ptr<BinPacking1D> mBinPacking1D;
 
     Collections::SequenceSet mTwoOptCheckedSequences;
 
     Collections::SequenceSet mEPHeurInfSequences;
     Collections::SequenceVector mCompleteFeasSeq;
+    std::unordered_map<double, Collections::IdVector> mCompleteFeasSeqWithTimeStamps;
+    std::unordered_map<double, Collections::IdVector> mTailTournamentConstraintsWithTimeStamps;
 
     /// Set of customer combinations that are infeasible.
     /// -> There is no path in combination C that respects all constraints

--- a/cpp/3L-VehicleRouting/ContainerLoading/src/LoadingChecker.cpp
+++ b/cpp/3L-VehicleRouting/ContainerLoading/src/LoadingChecker.cpp
@@ -283,10 +283,19 @@ boost::dynamic_bitset<> LoadingChecker::MakeBitset(size_t size, const Collection
     return set;
 };
 
+double LoadingChecker::GetElapsedTime()
+{
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - mStartTime;
+    return elapsed.count();
+}
+
 void LoadingChecker::AddFeasibleRoute(const Collections::IdVector& route)
 {
     mFeasSequences[Parameters.LoadingProblem.LoadingFlags].insert(route);
     mCompleteFeasSeq.push_back(route);
+    double elapsedAsDouble = GetElapsedTime();
+    mCompleteFeasSeqWithTimeStamps.insert({elapsedAsDouble, route});
 }
 
 void LoadingChecker::AddInfeasibleSequenceEP(const Collections::IdVector& sequence)

--- a/cpp/3L-VehicleRouting/VehicleRouting/include/VehicleRouting/Algorithms/BCRoutingParams.h
+++ b/cpp/3L-VehicleRouting/VehicleRouting/include/VehicleRouting/Algorithms/BCRoutingParams.h
@@ -147,6 +147,7 @@ struct BranchAndCutParams
     bool ActivateHeuristic = false;
     bool ActivateMemoryManagement = false;
     bool SimpleVersion = true;
+    bool TrackIncrementalFeasibilityProperty = false;
 };
 
 class InputParameters

--- a/cpp/3L-VehicleRouting/VehicleRouting/include/VehicleRouting/Algorithms/SubtourCallback.h
+++ b/cpp/3L-VehicleRouting/VehicleRouting/include/VehicleRouting/Algorithms/SubtourCallback.h
@@ -83,6 +83,8 @@ class SubtourCallback : public GRBCallback
         InitializeCuts();
     }
 
+    void SaveFeasibleAndPotentiallyExcludedRoutes() const;
+
   protected:
     GRBVar2D mVariablesX;
     const Instance* const mInstance;

--- a/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/BranchAndCutSolver.cpp
+++ b/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/BranchAndCutSolver.cpp
@@ -672,6 +672,9 @@ bool BranchAndCutSolver::CheckPath(const Collections::IdVector& path, Container&
     if (statusComplete == LoadingStatus::Infeasible)
     {
         mInfeasibleTailPaths.emplace_back(0, path.front(), path.back());
+
+        Collections::IdVector sequence = {path.front(), path.back()};
+        mLoadingChecker->AddTailTournamentConstraint(sequence);
     }
 
     return true;
@@ -892,6 +895,8 @@ void BranchAndCutSolver::Solve()
     branchAndCut.Solve(mInputParameters.MIPSolver);
 
     mTimer.BranchAndCut = std::chrono::system_clock::now() - start;
+
+    callback->SaveFeasibleAndPotentiallyExcludedRoutes();
 
     auto statistics = SolverStatistics(branchAndCut.GetRuntime(),
                                        branchAndCut.GetMIPGap(),

--- a/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/BranchAndCutSolver.cpp
+++ b/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/BranchAndCutSolver.cpp
@@ -896,7 +896,10 @@ void BranchAndCutSolver::Solve()
 
     mTimer.BranchAndCut = std::chrono::system_clock::now() - start;
 
-    callback->SaveFeasibleAndPotentiallyExcludedRoutes();
+    if (mInputParameters.BranchAndCut.TrackIncrementalFeasibilityProperty)
+    {
+        callback->SaveFeasibleAndPotentiallyExcludedRoutes();
+    }
 
     auto statistics = SolverStatistics(branchAndCut.GetRuntime(),
                                        branchAndCut.GetMIPGap(),

--- a/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/SubtourCallback.cpp
+++ b/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/SubtourCallback.cpp
@@ -620,20 +620,31 @@ bool SubtourCallback1D::CheckRoutes()
         mClock.end();
         CallbackTracker.UpdateElement(CallbackElement::MinNumVehicles, mClock.elapsed());
 
-        if (subtour.ConnectedToDepot && minVehicles < 2)
+        if (subtour.ConnectedToDepot)
         {
-            mLoadingChecker->AddFeasibleSequenceFromOutside(subtour.Sequence);
+            CallbackTracker.Counter[CallbackElement::Connected]++;
 
-            continue;
+            if (minVehicles < 2)
+            {
+                mLoadingChecker->AddFeasibleSequenceFromOutside(subtour.Sequence);
+
+                continue;
+            }
         }
 
         mClock.start();
         AddLazyConstraints({mLazyConstraintsGenerator->CreateConstraint(CutType::SEC, subtour.Sequence, minVehicles)});
         cutAdded = true;
         mClock.end();
-        CallbackTracker.UpdateElement(CallbackElement::MinVehApproxInf, mClock.elapsed());
 
-        cutAdded = true;
+        if (subtour.ConnectedToDepot)
+        {
+            CallbackTracker.UpdateElement(CallbackElement::MinVehApproxInf, mClock.elapsed());
+        }
+        else
+        {
+            CallbackTracker.UpdateElement(CallbackElement::Disconnected, mClock.elapsed());
+        }
     }
 
     return !cutAdded;

--- a/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/SubtourCallback.cpp
+++ b/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/SubtourCallback.cpp
@@ -1029,7 +1029,10 @@ LoadingStatus
     mClock.end();
     CallbackTracker.UpdateElement(CallbackElement::TailPathInequality, mClock.elapsed());
 
-    mLoadingChecker->AddTailTournamentConstraint(subtour.Sequence);
+    if (mInputParameters->BranchAndCut.TrackIncrementalFeasibilityProperty)
+    {
+        mLoadingChecker->AddTailTournamentConstraint(subtour.Sequence);
+    }
 
     // Check reverse path to
     //   - create new feasible route, or

--- a/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/SubtourCallback.cpp
+++ b/cpp/3L-VehicleRouting/VehicleRouting/src/Algorithms/SubtourCallback.cpp
@@ -508,9 +508,13 @@ void SubtourCallback::AddCuts(const std::vector<Cut>& cuts)
 
         if (cut.Type == CutType::RCC)
         {
+            // Since we are separating cuts in fractional solutions, it is appropriate to add them using AddCut. In
+            // fact, we also exclude integer solutions with our cuts, which is why we use the AddLazy method. See
+            // also:
+            // https://support.gurobi.com/hc/en-us/community/posts/32481416745745-Ignored-lazy-constraint-leads-to-wrong-solution-cont
             if (mCurrentNode == 0)
             {
-                this->addCut(lhs >= cut.RHS);
+                this->addLazy(lhs >= cut.RHS); // addCut
                 CallbackTracker.CutCounter[cut.Type]++;
             }
             else
@@ -522,14 +526,14 @@ void SubtourCallback::AddCuts(const std::vector<Cut>& cuts)
                 }
                 else
                 {
-                    this->addCut(lhs >= cut.RHS);
+                    this->addLazy(lhs >= cut.RHS); // addCut
                     CallbackTracker.CutCounter[cut.Type]++;
                 }
             }
         }
         else
         {
-            this->addCut(lhs >= cut.RHS);
+            this->addLazy(lhs >= cut.RHS); // addCut
             CallbackTracker.CutCounter[cut.Type]++;
         }
     }

--- a/cpp/3L-VehicleRouting/VehicleRouting/src/Helper/Serialization.cpp
+++ b/cpp/3L-VehicleRouting/VehicleRouting/src/Helper/Serialization.cpp
@@ -191,6 +191,7 @@ void from_json(const json& j, BranchAndCutParams& params)
     j.at("ActivateHeuristic").get_to(params.ActivateHeuristic);
     j.at("ActivateMemoryManagement").get_to(params.ActivateMemoryManagement);
     j.at("SimpleVersion").get_to(params.SimpleVersion);
+    j.at("TrackIncrementalFeasibilityProperty").get_to(params.TrackIncrementalFeasibilityProperty);
 }
 
 void to_json(json& j, const BranchAndCutParams& params)
@@ -208,7 +209,8 @@ void to_json(json& j, const BranchAndCutParams& params)
              {"TimeLimit", params.TimeLimits},
              {"ActivateHeuristic", params.ActivateHeuristic},
              {"ActivateMemoryManagement", params.ActivateMemoryManagement},
-             {"SimpleVersion", params.SimpleVersion}};
+             {"SimpleVersion", params.SimpleVersion},
+             {"TrackIncrementalFeasibilityProperty", params.TrackIncrementalFeasibilityProperty}};
 }
 
 void from_json(const json& j, UserCutParams& params)


### PR DESCRIPTION
This pull request introduces several important improvements and bug fixes for the 3L-CVRP branch-and-cut solver, with a focus on route feasibility tracking, cut generation correctness, and performance monitoring. The most notable changes include the addition of incremental feasibility property (IFP) tracking, restoration and correction of the FCI cut generation logic, enhanced time tracking for route feasibility, and improved handling of disconnected routes in the 1D SubtourTracker.

**Incremental feasibility tracking and performance monitoring:**
* Added support for tracking the incremental feasibility property (IFP) for routes, including new fields in `BranchAndCutParams`, timestamped storage of feasible routes and tail tournament constraints in `LoadingChecker`, and JSON output of these routes via `SubtourCallback::SaveFeasibleAndPotentiallyExcludedRoutes`.

**Cut generation and callback logic fixes:**
* Restored the original formulation of FCI (Framed Capacity Inequality) cut generation, correcting arc coefficients and right-hand side calculation, and fixed the logic for partition handling. 

**Placement point generation and loading subproblem bug fixes:**
* Fixed a bug in the logic for generating meet-in-the-middle placement points in the loading subproblem by ensuring left and right placement point sets do not overwrite each other, and refactored pattern naming for clarity. 

**1D SubtourTracker and disconnected route handling:**
* Updated the 1D SubtourTracker logic to properly handle disconnected routes, improving route feasibility checks and statistics tracking.

**General infrastructure and changelog:**
* Added a `CHANGELOG.md` file documenting all notable changes and adherence to semantic versioning and Keep a Changelog standards.